### PR TITLE
WS-49 Change Pitch/Yaw and Fix Build Errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -354,7 +354,7 @@
     "node_modules/@emotion/styled": {
       "version": "11.11.5",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
-      "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
+      "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrDIRECTION0Kb/pK7hk8BnLgLRi9KoQ==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -1840,7 +1840,7 @@
     "node_modules/@swc/core-darwin-x64": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.7.tgz",
-      "integrity": "sha512-RpUyu2GsviwTc2qVajPL0l8nf2vKj5wzO3WkLSHAHEJbiUZk83NJrZd1RVbEknIMO7+Uyjh54hEh8R26jSByaw==",
+      "integrity": "sha512-RpUyu2GsviwTc2qVajPL0l8nf2vKj5wzO3WkLSHAHEJbiUZk83NJrZd1RVbEknIMO7+Uyjh54hEh8R26jSBdirection==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1656,34 +1656,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
-      "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.34.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.4.tgz",
-      "integrity": "sha512-uuphLuw1X6ur11675c2twC6YxbzyLSpWggvdawTUamlsoUv81aAXRMPBC1uvQllnBGls0Qt5Siw8reSIBnbdqQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
+
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
       "version": "4.34.8",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",

--- a/src/Pages/PageUtility/DataStructures.ts
+++ b/src/Pages/PageUtility/DataStructures.ts
@@ -82,12 +82,12 @@ export interface Hotspot2D {
   data: HotspotData;
 }
 
-// Hotspot3D: a clickable resource that is inside a 360 photosphere (pitch, yaw)
+// Hotspot3D: a clickable resource that is inside a 360 photosphere (elevation, direction)
 export interface Hotspot3D {
   id: string;
   tooltip: string;
-  pitch: number;
-  yaw: number;
+  elevation: number;
+  direction: number;
   level: number;
   icon: Asset;
   data: HotspotData;

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -63,8 +63,8 @@ function PhotosphereEditor({
   const [showAddNavMap, setShowAddNavMap] = useState(false); // State to manage whether to show AddNavmap
 
   const [showAddHotspot, setShowAddHotspot] = useState(false);
-  const [pitch, setPitch] = useState(0);
-  const [yaw, setYaw] = useState(0);
+  const [elevation, setElevation] = useState(0);
+  const [direction, setDirection] = useState(0);
 
   const [showAddFeatures, setShowAddFeatures] = useState(false);
   const [showChangeFeatures, setShowChangeFeatures] = useState(false);
@@ -223,10 +223,10 @@ function PhotosphereEditor({
     setUpdateTrigger((prev) => prev + 1);
   }
 
-  /** Get and use pitch/yaw from viewer click */
-  function handleLocation(vpitch: number, vyaw: number) {
-    setPitch(radToDeg(vpitch));
-    setYaw(radToDeg(vyaw));
+  /** Get and use elevation/direction from viewer click */
+  function handleLocation(velevation: number, vdirection: number) {
+    setElevation(radToDeg(velevation));
+    setDirection(radToDeg(vdirection));
   }
 
   // Reset all states so we dont have issues with handling different components at the same time
@@ -237,8 +237,8 @@ function PhotosphereEditor({
     setShowChangePhotosphere(false);
     setShowRemovePhotosphere(false);
     setShowEditNavMap(false);
-    setPitch(0);
-    setYaw(0);
+    setElevation(0);
+    setDirection(0);
   }
 
   /** Render the actual component based on states */
@@ -268,8 +268,8 @@ function PhotosphereEditor({
         <AddHotspot
           onCancel={resetStates}
           onAddHotspot={handleAddHotspot}
-          pitch={pitch}
-          yaw={yaw}
+          elevation={elevation}
+          direction={direction}
           photosphereOptions={availablePhotosphereOptions}
         />
       );

--- a/src/PhotosphereFeatures/PhotosphereViewer.tsx
+++ b/src/PhotosphereFeatures/PhotosphereViewer.tsx
@@ -89,7 +89,7 @@ const StyledSwitch = styled((props: SwitchProps) => (
   },
 }));
 
-/** Convert yaw/pitch degrees from numbers to strings ending in "deg" */
+/** Convert direction/elevation degrees from numbers to strings ending in "deg" */
 function degToStr(val: number): string {
   return String(val) + "deg";
 }
@@ -113,8 +113,8 @@ function convertHotspots(
       id: hotspot.id,
       size: { width: 64, height: 64 },
       position: {
-        yaw: degToStr(hotspot.yaw),
-        pitch: degToStr(hotspot.pitch),
+        yaw: degToStr(hotspot.direction),
+        pitch: degToStr(hotspot.elevation),
       },
       tooltip: hotspot.tooltip,
     };
@@ -154,8 +154,8 @@ function convertLinks(
     links.push({
       nodeId: hotspot.data.photosphereID,
       position: {
-        pitch: degToStr(hotspot.pitch),
-        yaw: degToStr(hotspot.yaw),
+        pitch: degToStr(hotspot.elevation),
+        yaw: degToStr(hotspot.direction),
       },
       data: { tooltip: hotspot.tooltip } as LinkData,
     });
@@ -201,7 +201,7 @@ export interface PhotosphereViewerProps {
   vfe: VFE;
   currentPS: string;
   onChangePS: (id: string) => void;
-  onViewerClick?: (pitch: number, yaw: number) => void;
+  onViewerClick?: (elevation: number, direction: number) => void;
   onUpdateHotspot?: (
     hotspotPath: string[],
     update: HotspotUpdate | null,

--- a/src/Prototype/data.json
+++ b/src/Prototype/data.json
@@ -27,8 +27,8 @@
       "hotspots": {
         "OutcropWideView": {
           "id": "OutcropWideView",
-          "pitch": 5,
-          "yaw": -5,
+          "elevation": 5,
+          "direction": -5,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -50,8 +50,8 @@
         },
         "Flowers": {
           "id": "Flowers",
-          "pitch": -3,
-          "yaw": 18,
+          "elevation": -3,
+          "direction": 18,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -73,8 +73,8 @@
         },
         "URLDemo": {
           "id": "URLDemo",
-          "pitch": -10,
-          "yaw": 0,
+          "elevation": -10,
+          "direction": 0,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -89,8 +89,8 @@
         },
         "AudioDemo": {
           "id": "AudioDemo",
-          "pitch": -10,
-          "yaw": 10,
+          "elevation": -10,
+          "direction": 10,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -109,8 +109,8 @@
         },
         "DocumentDemo": {
           "id": "DocumentDemo",
-          "pitch": -10,
-          "yaw": 20,
+          "elevation": -10,
+          "direction": 20,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -129,8 +129,8 @@
         },
         "ShorelineSOUTH": {
           "id": "ShorelineSOUTH",
-          "pitch": -32,
-          "yaw": 172,
+          "elevation": -32,
+          "direction": 172,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-red.png",
@@ -149,8 +149,8 @@
         },
         "Paddlers": {
           "id": "Paddlers",
-          "pitch": -10,
-          "yaw": -175,
+          "elevation": -10,
+          "direction": -175,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-red.png",
@@ -169,8 +169,8 @@
         },
         "SmallPool": {
           "id": "SmallPool",
-          "pitch": -13,
-          "yaw": 100,
+          "elevation": -13,
+          "direction": 100,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -192,8 +192,8 @@
         },
         "LogNearShoreline": {
           "id": "LogNearShoreline",
-          "pitch": -25,
-          "yaw": -40,
+          "elevation": -25,
+          "direction": -40,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -215,8 +215,8 @@
         },
         "CoolLog": {
           "id": "CoolLog",
-          "pitch": -17,
-          "yaw": -33,
+          "elevation": -17,
+          "direction": -33,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -238,8 +238,8 @@
         },
         "OutcropTextures": {
           "id": "OutcropTextures",
-          "pitch": 6,
-          "yaw": 5,
+          "elevation": 6,
+          "direction": 5,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-red.png",
@@ -258,8 +258,8 @@
         },
         "HugeLogs": {
           "id": "HugeLogs",
-          "pitch": -12,
-          "yaw": -37,
+          "elevation": -12,
+          "direction": -37,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -274,8 +274,8 @@
         },
         "Mushroom": {
           "id": "Mushroom",
-          "pitch": 2,
-          "yaw": -19,
+          "elevation": 2,
+          "direction": -19,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -297,8 +297,8 @@
         },
         "Contact": {
           "id": "Contact",
-          "pitch": 2,
-          "yaw": -46,
+          "elevation": 2,
+          "direction": -46,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -377,8 +377,8 @@
         },
         "SouthWaterfront": {
           "id": "SouthWaterfront",
-          "pitch": -1,
-          "yaw": -25,
+          "elevation": -1,
+          "direction": -25,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -400,8 +400,8 @@
         },
         "Go West": {
           "id": "Go West",
-          "pitch": 0,
-          "yaw": -35,
+          "elevation": 0,
+          "direction": -35,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -416,8 +416,8 @@
         },
         "Go to Entrance": {
           "id": "Go to Entrance",
-          "pitch": -7,
-          "yaw": 125,
+          "elevation": -7,
+          "direction": 125,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -448,8 +448,8 @@
       "hotspots": {
         "Go East": {
           "id": "Go East",
-          "pitch": -2,
-          "yaw": -4,
+          "elevation": -2,
+          "direction": -4,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -464,8 +464,8 @@
         },
         "Go South": {
           "id": "Go South",
-          "pitch": -4,
-          "yaw": -78,
+          "elevation": -4,
+          "direction": -78,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -491,8 +491,8 @@
       "hotspots": {
         "Go North": {
           "id": "Go North",
-          "pitch": 0,
-          "yaw": 10,
+          "elevation": 0,
+          "direction": 10,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -507,8 +507,8 @@
         },
         "Go South": {
           "id": "Go South",
-          "pitch": -3,
-          "yaw": 115,
+          "elevation": -3,
+          "direction": 115,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -534,8 +534,8 @@
       "hotspots": {
         "Go West": {
           "id": "Go West",
-          "pitch": 0,
-          "yaw": -130,
+          "elevation": 0,
+          "direction": -130,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -550,8 +550,8 @@
         },
         "Go East": {
           "id": "Go East",
-          "pitch": 0,
-          "yaw": 92,
+          "elevation": 0,
+          "direction": 92,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -577,8 +577,8 @@
       "hotspots": {
         "Go North": {
           "id": "Go North",
-          "pitch": 3,
-          "yaw": 2,
+          "elevation": 3,
+          "direction": 2,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",
@@ -593,8 +593,8 @@
         },
         "Go to Entrance": {
           "id": "Go to Entrance",
-          "pitch": -2,
-          "yaw": -167,
+          "elevation": -2,
+          "direction": -167,
           "icon": {
             "tag": "Runtime",
             "path": "/pin-blue.png",

--- a/src/buttons/AddHotspot.tsx
+++ b/src/buttons/AddHotspot.tsx
@@ -432,16 +432,16 @@ export function HotspotIconEditor({
 interface AddHotspotProps {
   onAddHotspot: (newHotspot: Hotspot3D) => void;
   onCancel: () => void;
-  pitch: number;
-  yaw: number;
+  elevation: number;
+  direction: number;
   photosphereOptions: string[];
 }
 
 function AddHotspot({
   onAddHotspot,
   onCancel,
-  pitch,
-  yaw,
+  elevation,
+  direction,
   photosphereOptions,
 }: AddHotspotProps) {
   const [tooltip, setTooltip] = useState("");
@@ -469,8 +469,8 @@ function AddHotspot({
     const newHotspot: Hotspot3D = {
       id: newID(),
       tooltip: generatedTooltip,
-      pitch,
-      yaw,
+      elevation,
+      direction,
       level,
       icon: iconAsset ?? defaultIcon(), // store default icon for photosphere links
       data: hotspotData,
@@ -500,22 +500,22 @@ function AddHotspot({
       <Typography variant="h5" sx={{ textAlign: "center" }}>
         Add a Hotspot
       </Typography>
-      <Typography>Double click spot for pitch and yaw</Typography>
+      <Typography>Double click spot for elevation and direction</Typography>
       <Stack direction="row" gap={1}>
         <TextField
-          label="Pitch"
+          label="Elevation"
           InputProps={{
             readOnly: true,
           }}
-          defaultValue={String(pitch.toFixed(2))}
+          defaultValue={String(elevation.toFixed(2))}
           sx={{ flexGrow: 1 }}
         />
         <TextField
-          label="Yaw"
+          label="Direction"
           InputProps={{
             readOnly: true,
           }}
-          defaultValue={String(yaw.toFixed(2))}
+          defaultValue={String(direction.toFixed(2))}
           sx={{ flexGrow: 1 }}
         />
       </Stack>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": ["node", "react", "react-dom"], 
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
This PR addresses issues related to typescript errors, duplicate object keys, and refactoring of pitch/yaw to direction/elevation. This eliminates the confusion of the language used, making the VFE more user friendly. 

Changes Made: 
- Fixed typescript build error by adding a types array to tsconfig.json to resolve recurring typescript build error due to missing types. 
- Removed duplicate object keys from package-lock.json to resolve typescript errors. 
- Replaced instances of Pitch and Yaw with Elevation and Direction where applicable
- Maintained use of Pitch and Yaw only where the data structure is sourced from external libraries 

Testing: 
- Checked again for typescript errors
- Verified with new VFE hotspot creation to confirm that UI correctly displays Direction and Elevation