### PR TITLE
Add Background Audio Volume Control to Viewer

### DIFF
--- a/src/PhotosphereFeatures/PhotosphereViewer.tsx
+++ b/src/PhotosphereFeatures/PhotosphereViewer.tsx
@@ -345,7 +345,7 @@ function PhotosphereViewer({
           top: "16px",
           left: 0,
           right: 0,
-          maxWidth: "420px",
+          maxWidth: "100%",
           width: "fit-content",
           minWidth: "150px",
           height: "45px",

--- a/src/buttons/AudioToggleButton.tsx
+++ b/src/buttons/AudioToggleButton.tsx
@@ -1,52 +1,131 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 
-import { Button, Stack, Typography } from "@mui/material";
+import { Button, Stack, IconButton, Slider, Tooltip } from "@mui/material";
+
+import VolumeUpIcon from "@mui/icons-material/VolumeUp";
+import VolumeOffIcon from "@mui/icons-material/VolumeOff";
+import PauseIcon from "@mui/icons-material/Pause";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 
 export interface AudioToggleButtonProps {
   src: string;
 }
 
-function AudioToggleButton(props: AudioToggleButtonProps) {
-  const [isAudioPlaying, setIsAudioPlaying] = useState(false);
+// sessionStorage keys, audio settings reset after closing browser
+const VOLUME_KEY = "vfe-audio-volume";
+const MUTE_KEY = "vfe-audio-muted";
 
+function AudioToggleButton({ src }: AudioToggleButtonProps) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  // Mute statea, initialized from sessionStorage 
+  const [isMuted, setIsMuted] = useState(() => {
+    return sessionStorage.getItem(MUTE_KEY) === "true";
+  });
+  // Audio volume (from 0.0-1.0), initialized from sessionStorage
+  const [volume, setVolume] = useState(() => {
+    const stored = sessionStorage.getItem(VOLUME_KEY);
+    return stored ? parseFloat(stored) : 1;
+  });
+
+  /* Set up the audio element when component mounts or src changes. 
+   * Loops the audio and applies the current volume and mute states. 
+   * Clean up by pausing audio and clearning audioRef. 
+   */
   useEffect(() => {
-    const audio = new Audio(props.src);
-    // Check if theres user interaction
-    if (isAudioPlaying) {
-      //Make a new audio object with the imported audio file
-      //Try to play the audio file, have to use void to indicate were not going to promise to handle the returned type
-      void audio.play().catch((e) => {
-        //Debug for errors
-        console.error("Error playing audio:", e);
-      });
-    }
-    //Cleanup function to pause audio when the component unmounts
+    const audio = new Audio(src);
+    audio.loop = true;
+    audio.volume = volume;
+    audio.muted = isMuted;
+    audioRef.current = audio;
+
     return () => {
-      if (isAudioPlaying) {
-        audio.pause();
-      }
+      audio.pause();
+      audioRef.current = null;
     };
-    //Depends on the isUserInteracted state, reruns if it changes
-  }, [isAudioPlaying, props.src]);
+  }, [src]);
 
-  //toggles state of audio upon button press
-  function toggleAudio() {
-    setIsAudioPlaying((prevIsAudioPlaying) => !prevIsAudioPlaying);
-  }
+  // Handle Play Audio button clicks
+  const handlePlay = async () => {
+    try {
+      await audioRef.current?.play();
+      setIsPlaying(true);
+    } catch (error) {
+      console.warn("Playback failed:", error);
+    }
+  };
 
+  // Handle Pause Audio button clicks 
+  const handlePause = () => {
+    audioRef.current?.pause();
+    setIsPlaying(false);
+  };
+
+  // Toggles the mute state and updates sessionStorage and audio element
+  const handleMuteToggle = () => {
+    const newMuted = !isMuted;
+    setIsMuted(newMuted);
+    sessionStorage.setItem(MUTE_KEY, String(newMuted));
+    if (audioRef.current) {
+      audioRef.current.muted = newMuted;
+    }
+  };
+
+  /* Updates volume state and reflects change in audio element. 
+   * Handles auto muting when volume is 0.0
+   */
+  const handleVolumeChange = (_: Event, value: number | number[]) => {
+    const newVolume = typeof value === "number" ? value : value[0];
+    setVolume(newVolume);
+    sessionStorage.setItem(VOLUME_KEY, newVolume.toString());
+    if (audioRef.current) {
+      audioRef.current.volume = newVolume;
+      if (newVolume === 0) {
+        setIsMuted(true);
+        audioRef.current.muted = true;
+      } else {
+        setIsMuted(false);
+        audioRef.current.muted = false;
+      }
+    }
+  };
+
+  // UI rendering, shows play button by default, show pause & slider if playing 
   return (
-    <Stack sx={{ justifyContent: "space-around", padding: "0 5px" }}>
-      <Button
-        onClick={toggleAudio}
-        variant="outlined"
-        sx={{
-          height: "35px",
-        }}
-      >
-        <Typography sx={{ fontSize: "14px" }}>
-          {isAudioPlaying ? "Pause Audio" : "Play Audio"}
-        </Typography>
-      </Button>
+    <Stack direction="row" alignItems="center" spacing={1}>
+      {!isPlaying ? (
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={handlePlay}
+          startIcon={<PlayArrowIcon />}
+        >
+          Play Audio
+        </Button>
+      ) : (
+        <>
+          <Tooltip title={isMuted ? "Unmute" : "Mute"}>
+            <IconButton onClick={handleMuteToggle} size="small">
+              {isMuted || volume === 0 ? <VolumeOffIcon /> : <VolumeUpIcon />}
+            </IconButton>
+          </Tooltip>
+
+          <Slider
+            value={isMuted ? 0 : volume}
+            min={0}
+            max={1}
+            step={0.01}
+            onChange={handleVolumeChange}
+            sx={{ width: 100 }}
+          />
+
+          <Tooltip title="Pause Audio">
+            <IconButton onClick={handlePause} size="small">
+              <PauseIcon />
+            </IconButton>
+          </Tooltip>
+        </>
+      )}
     </Stack>
   );
 }


### PR DESCRIPTION
This PR introduces interactive audio controls for the background audio of the VFE. It improves the user experience by giving them more control over the playback and volume without persisting settings across different sessions.

Changes:
AudioToggleButton.tsx: Additions to the majority of the code allows for volume control including a volume control slider (viewable after the user clicks Play Audio) and mute/unmute button.

Testing:

Confirmed that audio does not play by default.
Verified that slider updates volume in real time.
Verified that mute button behavior is synced with volume state.
Confirmed session persistence.

<img width="554" alt="Screen Shot 2025-04-21 at 8 21 21 AM" src="https://github.com/user-attachments/assets/1e6ee8cc-3c9f-44f8-a32f-500409341bb4" />
