### PR TITLE
Ws 61 points system interface and storage

### DIFF
--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -1,8 +1,13 @@
 import localforage from "localforage";
 
-//Initialize or Reset Points
+// Using a separite instance of localforage so we dont interfere with loading of VFEs
+const pointsStore = localforage.createInstance({
+  name: "pointsStore",
+});
+
+//Can also be used to reset points
 export function InitializePoints() {
-  localforage
+  pointsStore
     .setItem("Points", 0)
     .then(() => {
       console.log("Points initialized successfully!");
@@ -12,15 +17,15 @@ export function InitializePoints() {
     });
 }
 
-//Increment Points by Amount
+//Increment Points by Amount, must be whole number
 export async function AddPoints(amount: number) {
-  let points = await localforage.getItem<number>("Points");
+  let points = await pointsStore.getItem<number>("Points");
 
   if (points != null) {
     points = points + amount;
   } else return;
 
-  localforage
+  pointsStore
     .setItem("Points", points)
     .then(() => {
       console.log("Points updated successfully! New points are: " + points);
@@ -35,7 +40,7 @@ export async function AddPoints(amount: number) {
 export function PointsDisplay() {
   //use effect for constant updates?
 
-  localforage
+  pointsStore
     .getItem("Points")
     .then((data) => {
       console.log("Retrieved points:", data);

--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable func-style */
 import localforage from "localforage";
+import { useSyncExternalStore } from "react";
 
 // Using a separite instance of localforage so we dont interfere with loading of VFEs
 const pointsStore = localforage.createInstance({
@@ -8,10 +10,21 @@ const pointsStore = localforage.createInstance({
 let maxPoints = 100;
 const points = await pointsStore.getItem<number>("Points");
 
-export function getPointTotal() {
-  console.log("Points total:" + points);
-  return points ?? 0;
-}
+export const getPoints = () => {
+  return points;
+};
+
+export const subscribe = (callback: () => void): (() => void) => {
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+  };
+};
+
+// export function getPointTotal() {
+//   console.log("Points total:" + points);
+//   return points ?? 0;
+// }
 
 export function getMaxPoints() {
   //use effect for constant updates?
@@ -23,6 +36,7 @@ export function InitializePoints() {
   pointsStore
     .setItem("Points", 0)
     .then(() => {
+      window.dispatchEvent(new Event("storage"));
       console.log("Points initialized successfully!");
     })
     .catch((error) => {
@@ -42,12 +56,16 @@ export async function AddPoints(amount: number) {
 
   if (points != null) {
     points = points + amount;
-  } else return;
+  } else {
+    console.log("No Points!");
+    return;
+  }
 
   pointsStore
     .setItem("Points", points)
     .then(() => {
       console.log("Points updated successfully! New points are: " + points);
+      window.dispatchEvent(new Event("storage"));
       return;
     })
     .catch((error) => {

--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -5,6 +5,19 @@ const pointsStore = localforage.createInstance({
   name: "pointsStore",
 });
 
+let maxPoints = 100;
+const points = await pointsStore.getItem<number>("Points");
+
+export function getPointTotal() {
+  console.log("Points total:" + points);
+  return points ?? 0;
+}
+
+export function getMaxPoints() {
+  //use effect for constant updates?
+  return maxPoints;
+}
+
 //Can also be used to reset points
 export function InitializePoints() {
   pointsStore
@@ -15,7 +28,13 @@ export function InitializePoints() {
     .catch((error) => {
       console.error("Error storing data:", error);
     });
+
+  //initialize this if component does not exist, load from VFE save data otherwise
+  maxPoints = 100;
 }
+
+// will need a set maxPoints function eventually that saves the max points to VFE
+// save data when changed in the editor
 
 //Increment Points by Amount, must be whole number
 export async function AddPoints(amount: number) {
@@ -36,16 +55,14 @@ export async function AddPoints(amount: number) {
     });
 }
 
-// Show current points
-export function PointsDisplay() {
-  //use effect for constant updates?
+// export async function GetProgressBarData() {
+//   const [points, setPoints] = useState(0);
+//   const maxPoints = getMaxPoints();
+//   const pointsFromMemory = await getPointTotal();
 
-  pointsStore
-    .getItem("Points")
-    .then((data) => {
-      console.log("Retrieved points:", data);
-    })
-    .catch((error) => {
-      console.error("Error retrieving data:", error);
-    });
-}
+//   useEffect(() => {
+//     setPoints(pointsFromMemory ? pointsFromMemory : 0);
+//   }, [pointsFromMemory]);
+
+//   return [points, maxPoints];
+// }

--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -1,6 +1,6 @@
 import localforage from "localforage";
 
-//Initialize Points
+//Initialize or Reset Points
 export function InitializePoints() {
   localforage
     .setItem("Points", 0)

--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -1,0 +1,46 @@
+import localforage from "localforage";
+
+//Initialize Points
+export function InitializePoints() {
+  localforage
+    .setItem("Points", 0)
+    .then(() => {
+      console.log("Points initialized successfully!");
+    })
+    .catch((error) => {
+      console.error("Error storing data:", error);
+    });
+}
+
+//Increment Points by Amount
+export async function AddPoints(amount: number) {
+  let points = await localforage.getItem<number>("Points");
+
+  if (points != null) {
+    points = points + amount;
+  } else return;
+
+  localforage
+    .setItem("Points", points)
+    .then(() => {
+      console.log("Points updated successfully! New points are: " + points);
+      return;
+    })
+    .catch((error) => {
+      console.error("Error storing data:", error);
+    });
+}
+
+// Show current points
+export function PointsDisplay() {
+  //use effect for constant updates?
+
+  localforage
+    .getItem("Points")
+    .then((data) => {
+      console.log("Retrieved points:", data);
+    })
+    .catch((error) => {
+      console.error("Error retrieving data:", error);
+    });
+}

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -502,15 +502,6 @@ function PhotosphereEditor({
             >
               Gamify!
             </Button>
-            <Button
-              sx={{ margin: "10px 0" }}
-              onClick={() => {
-                void AddPoints(10);
-              }}
-              variant="contained"
-            >
-              Add Points!
-            </Button>
           </>
         )}
         {showAddFeatures && (

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -25,11 +25,7 @@ import {
   photosphereLinkTooltip,
 } from "./PageUtility/DataStructures.ts";
 import { deleteStoredVFE, save } from "./PageUtility/FileOperations.ts";
-import {
-  AddPoints,
-  InitializePoints,
-  PointsDisplay,
-} from "./PageUtility/PointsInterface.tsx";
+import { InitializePoints } from "./PageUtility/PointsInterface.tsx";
 import {
   HotspotUpdate,
   convertRuntimeToStored,

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -5,6 +5,16 @@ import { useNavigate } from "react-router-dom";
 import AttachFileIcon from "@mui/icons-material/AttachFile";
 import { Box, Button, Stack } from "@mui/material";
 
+import { VisitedState } from "../Hooks/HandleVisit.tsx";
+import PhotosphereViewer from "../PhotosphereFeatures/PhotosphereViewer.tsx";
+import { alertMUI, confirmMUI } from "../UI/StyledDialogWrapper.tsx";
+import AddAudio from "../buttons/AddAudio.tsx";
+import AddHotspot from "../buttons/AddHotspot.tsx";
+import AddNavmap from "../buttons/AddNavmap.tsx";
+import AddPhotosphere from "../buttons/AddPhotosphere.tsx";
+import ChangePhotosphere from "../buttons/ChangePhotosphere.tsx";
+import EditNavMap from "../buttons/EditNavMap.tsx";
+import RemovePhotosphere from "../buttons/RemovePhotosphere.tsx";
 import {
   Hotspot3D,
   NavMap,
@@ -15,22 +25,17 @@ import {
   photosphereLinkTooltip,
 } from "./PageUtility/DataStructures.ts";
 import { deleteStoredVFE, save } from "./PageUtility/FileOperations.ts";
-import { VisitedState } from "../Hooks/HandleVisit.tsx";
-import PhotosphereViewer from "../PhotosphereFeatures/PhotosphereViewer.tsx";
-import { alertMUI, confirmMUI } from "../UI/StyledDialogWrapper.tsx";
+import {
+  AddPoints,
+  InitializePoints,
+  PointsDisplay,
+} from "./PageUtility/PointsInterface.tsx";
 import {
   HotspotUpdate,
   convertRuntimeToStored,
   convertVFE,
   updatePhotosphereHotspot,
 } from "./PageUtility/VFEConversion.ts";
-import AddAudio from "../buttons/AddAudio.tsx";
-import AddHotspot from "../buttons/AddHotspot.tsx";
-import AddNavmap from "../buttons/AddNavmap.tsx";
-import AddPhotosphere from "../buttons/AddPhotosphere.tsx";
-import ChangePhotosphere from "../buttons/ChangePhotosphere.tsx";
-import EditNavMap from "../buttons/EditNavMap.tsx";
-import RemovePhotosphere from "../buttons/RemovePhotosphere.tsx";
 
 /** Convert from radians to degrees */
 function radToDeg(num: number): number {
@@ -487,6 +492,24 @@ function PhotosphereEditor({
               variant="contained"
             >
               Export
+            </Button>
+            <Button
+              sx={{ margin: "10px 0" }}
+              onClick={() => {
+                InitializePoints();
+              }}
+              variant="contained"
+            >
+              Gamify!
+            </Button>
+            <Button
+              sx={{ margin: "10px 0" }}
+              onClick={() => {
+                void AddPoints(10);
+              }}
+              variant="contained"
+            >
+              Add Points!
             </Button>
           </>
         )}

--- a/src/PhotosphereFeatures/PhotosphereViewer.tsx
+++ b/src/PhotosphereFeatures/PhotosphereViewer.tsx
@@ -12,6 +12,11 @@ import {
 } from "@mui/material";
 
 import { Photosphere, VFE } from "../Pages/PageUtility/DataStructures";
+import {
+  AddPoints,
+  InitializePoints,
+  PointsDisplay,
+} from "../Pages/PageUtility/PointsInterface";
 import { HotspotUpdate } from "../Pages/PageUtility/VFEConversion";
 import AudioToggleButton from "../buttons/AudioToggleButton";
 import PhotospherePlaceholder from "./PhotospherePlaceholder";
@@ -212,6 +217,18 @@ function PhotosphereViewer({
           }}
           sx={{ margin: 0 }}
         />
+        <Box sx={{ padding: "0 5px" }}>
+          <Button
+            sx={{ padding: "0", width: "4px", height: "40px" }}
+            variant="contained"
+            color="primary"
+            onClick={() => {
+              void AddPoints(10);
+            }}
+          >
+            Add Points!
+          </Button>
+        </Box>
       </Stack>
 
       <Stack

--- a/src/PhotosphereFeatures/PhotosphereViewer.tsx
+++ b/src/PhotosphereFeatures/PhotosphereViewer.tsx
@@ -1,5 +1,5 @@
 import localforage from "localforage";
-import React, { useState } from "react";
+import React, { useEffect, useState, useSyncExternalStore } from "react";
 import { ViewerAPI } from "react-photo-sphere-viewer";
 
 import {
@@ -16,7 +16,8 @@ import { Photosphere, VFE } from "../Pages/PageUtility/DataStructures";
 import {
   AddPoints,
   getMaxPoints,
-  getPointTotal,
+  getPoints,
+  subscribe,
 } from "../Pages/PageUtility/PointsInterface";
 import { HotspotUpdate } from "../Pages/PageUtility/VFEConversion";
 import AudioToggleButton from "../buttons/AudioToggleButton";
@@ -122,7 +123,7 @@ function PhotosphereViewer({
   const [isSplitView, setIsSplitView] = useState(false);
   const [lockViews, setLockViews] = useState(false);
 
-  const points = getPointTotal();
+  const points = useSyncExternalStore(subscribe, getPoints);
   const maxPoints = getMaxPoints();
 
   const viewerProps: ViewerProps = {
@@ -290,7 +291,7 @@ function PhotosphereViewer({
         }}
         gap={1}
       >
-        <progress value={points} max={maxPoints} />{" "}
+        <progress value={points ?? 0} max={maxPoints} />{" "}
       </Stack>
     </>
   );

--- a/src/PhotosphereFeatures/PhotosphereViewer.tsx
+++ b/src/PhotosphereFeatures/PhotosphereViewer.tsx
@@ -1,3 +1,4 @@
+import localforage from "localforage";
 import React, { useState } from "react";
 import { ViewerAPI } from "react-photo-sphere-viewer";
 
@@ -14,8 +15,8 @@ import {
 import { Photosphere, VFE } from "../Pages/PageUtility/DataStructures";
 import {
   AddPoints,
-  InitializePoints,
-  PointsDisplay,
+  getMaxPoints,
+  getPointTotal,
 } from "../Pages/PageUtility/PointsInterface";
 import { HotspotUpdate } from "../Pages/PageUtility/VFEConversion";
 import AudioToggleButton from "../buttons/AudioToggleButton";
@@ -120,6 +121,9 @@ function PhotosphereViewer({
 
   const [isSplitView, setIsSplitView] = useState(false);
   const [lockViews, setLockViews] = useState(false);
+
+  const points = getPointTotal();
+  const maxPoints = getMaxPoints();
 
   const viewerProps: ViewerProps = {
     vfe,
@@ -230,7 +234,6 @@ function PhotosphereViewer({
           </Button>
         </Box>
       </Stack>
-
       <Stack
         direction="row"
         sx={{
@@ -264,6 +267,30 @@ function PhotosphereViewer({
             lockViews={lockViews}
           />
         )}
+      </Stack>
+      <Stack
+        direction="row"
+        sx={{
+          position: "absolute",
+          bottom: "44px",
+          left: 0,
+          right: 0,
+          maxWidth: "100%",
+          width: "fit-content",
+          minWidth: "150px",
+          height: "25px",
+          padding: "4px",
+          margin: "auto",
+          backgroundColor: "white",
+          borderRadius: "4px",
+          boxShadow: "0 0 4px grey",
+          zIndex: 100,
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+        gap={1}
+      >
+        <progress value={points} max={maxPoints} />{" "}
       </Stack>
     </>
   );

--- a/src/PhotosphereFeatures/PhotosphereViewer.tsx
+++ b/src/PhotosphereFeatures/PhotosphereViewer.tsx
@@ -1,5 +1,4 @@
-import localforage from "localforage";
-import React, { useEffect, useState, useSyncExternalStore } from "react";
+import React, { useState } from "react";
 import { ViewerAPI } from "react-photo-sphere-viewer";
 
 import {
@@ -13,12 +12,7 @@ import {
 } from "@mui/material";
 
 import { Photosphere, VFE } from "../Pages/PageUtility/DataStructures";
-import {
-  AddPoints,
-  getMaxPoints,
-  getPoints,
-  subscribe,
-} from "../Pages/PageUtility/PointsInterface";
+import { usePoints } from "../Pages/PageUtility/PointsInterface";
 import { HotspotUpdate } from "../Pages/PageUtility/VFEConversion";
 import AudioToggleButton from "../buttons/AudioToggleButton";
 import PhotospherePlaceholder from "./PhotospherePlaceholder";
@@ -123,8 +117,8 @@ function PhotosphereViewer({
   const [isSplitView, setIsSplitView] = useState(false);
   const [lockViews, setLockViews] = useState(false);
 
-  const points = useSyncExternalStore(subscribe, getPoints);
-  const maxPoints = getMaxPoints();
+  const [points, AddPoints] = usePoints();
+  const maxPoints = 100;
 
   const viewerProps: ViewerProps = {
     vfe,


### PR DESCRIPTION
Created a points interface that handles setting up and updating a points total in local storage using the localForage library, as well as a progress bar that displays the overall current point totals. Two buttons have been added for testing and demonstration, one in the editor (Gamify!) and one in the viewer (Add Points) that also shows up in the editor. The gamify button sets up the local storage if it is not prepared already, and sets or resets the current point total to 0. The Add Points button adds 10 points to the score. Current max points is 100, will eventually make that into a user-defined value.

Known issues: Reset is not dynamic yet.

If you find any other issues, please let me know! Major MVP props to Braulee for his help!
