### PR TITLE
Ws 33 update UI for split view

### DIFF
--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -215,7 +215,7 @@ function PhotospherePlaceholder({
         getLinkTooltip(_content: string, link: VirtualTourLink): string {
           return (link.data as LinkData).tooltip;
         },
-      } as VirtualTourPluginConfig,
+      } as unknown as VirtualTourPluginConfig, // needed to make build happy
     ],
   ];
   isPrimary &&
@@ -285,7 +285,8 @@ function PhotospherePlaceholder({
 
     virtualTour.setNodes(nodes, currentPS);
     virtualTour.addEventListener("node-changed", ({ node }) => {
-      setCurrentPhotosphere(vfe.photospheres[node.id]);
+      // want to travel both viewers
+      states.setStates.forEach((func) => func(vfe.photospheres[node.id]));
       onChangePS(node.id);
       setHotspotArray([]); // clear popovers on scene change
     });

--- a/src/PhotosphereFeatures/PhotosphereViewer.tsx
+++ b/src/PhotosphereFeatures/PhotosphereViewer.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   Switch,
   SwitchProps,
+  Typography,
   styled,
 } from "@mui/material";
 
@@ -169,14 +170,17 @@ function PhotosphereViewer({
         {isSplitView && (
           <Box>
             <Button
-              sx={{ padding: "0", width: "4px", height: "40px" }}
-              variant="contained"
-              color={lockViews ? "primary" : "secondary"}
+              variant={lockViews ? "contained" : "outlined"}
+              sx={{
+                height: "35px",
+              }}
               onClick={() => {
                 setLockViews(!lockViews);
               }}
             >
-              Lock Views
+              <Typography sx={{ fontSize: "14px" }}>
+                {lockViews ? "Unl" : "L"}ock Views
+              </Typography>
             </Button>
           </Box>
         )}

--- a/src/PhotosphereFeatures/PhotosphereViewer.tsx
+++ b/src/PhotosphereFeatures/PhotosphereViewer.tsx
@@ -140,7 +140,6 @@ function PhotosphereViewer({
           top: "16px",
           left: 0,
           right: 0,
-          maxWidth: "420px",
           width: "fit-content",
           minWidth: "150px",
           height: "45px",

--- a/src/PhotosphereFeatures/PhotosphereViewer.tsx
+++ b/src/PhotosphereFeatures/PhotosphereViewer.tsx
@@ -157,14 +157,13 @@ function PhotosphereViewer({
       >
         <Box sx={{ padding: "0 5px" }}>
           <Button
-            sx={{ padding: "0", width: "4px", height: "40px" }}
-            variant="contained"
-            color="primary"
+            sx={{ height: "35px" }}
+            variant="outlined"
             onClick={() => {
               setIsSplitView(!isSplitView);
             }}
           >
-            Split View
+            <Typography sx={{ fontSize: "14px" }}>Split View</Typography>
           </Button>
         </Box>
         {isSplitView && (


### PR DESCRIPTION
# UI Changes
Improved the split view and lock buttons to better match the 
current site's style. Small PR. 

# Functionality Changes
Needed to make it so when the user clicks the navigation hotspot
both scenes travel to the new scene so they stay synchronized.

# Build changes
Added a type conversion to the VirtualTourPluginConfig so the
type system stopped complaining when building the project.

# Testing
Ran the project on Firefox browsers and played around with it. 
Everything works fine. `npm run build` also didn't give me any
errors.