### PR TITLE
WS-45 maintain nesting level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vs/*

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -132,6 +132,9 @@ function PhotosphereEditor({
       },
     };
 
+    sessionStorage.setItem('lastEditedHotspot', JSON.stringify(hotspotPath));
+    sessionStorage.setItem('lastEditedHotspotFlag', "1");
+
     onUpdateVFE(updatedVFE);
     setUpdateTrigger((prev) => prev + 1);
   }

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -243,20 +243,22 @@ function PhotospherePlaceholder({
       // setCurrentPhotosphere has to be used to get the current state value because
       // the value of currentPhotosphere does not get updated in an event listener
       setCurrentPhotosphere((currentState) => {
-        let passMarker = currentState.hotspots[marker.config.id];
-        let passMarkerList = [passMarker];
+        let passMarker: Hotspot2D | Hotspot3D = currentState.hotspots[marker.config.id];
+        let passMarkerList: (Hotspot2D | Hotspot3D)[] = [passMarker];
 
         const lastEditedHotspotFlag = Number(sessionStorage.getItem('lastEditedHotspotFlag'));
-        const lastEditedHotspot = JSON.parse(sessionStorage.getItem('lastEditedHotspot'));
+        const lastEditedHotspot = JSON.parse(sessionStorage.getItem('lastEditedHotspot') || "{}");
 
         if (lastEditedHotspotFlag == 1 && lastEditedHotspot != null && lastEditedHotspot.length > 1 && lastEditedHotspot[0] == marker.config.id) {
           for (let i = 1; i < lastEditedHotspot.length; ++i) {
-            passMarkerList.push( passMarker.data.hotspots[lastEditedHotspot[i]] );
-            passMarker = passMarker.data.hotspots[lastEditedHotspot[i]];
+            if (passMarker.data.tag == "Image") {
+              passMarkerList.push( passMarker.data.hotspots[lastEditedHotspot[i]] );
+              passMarker = passMarker.data.hotspots[lastEditedHotspot[i]];
+            }
           }
           sessionStorage.setItem('lastEditedHotspotFlag', "0");
         }
-
+        
         setHotspotArray(passMarkerList);
         handleVisit(currentState.id, marker.config.id);
         return currentState;

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -243,8 +243,21 @@ function PhotospherePlaceholder({
       // setCurrentPhotosphere has to be used to get the current state value because
       // the value of currentPhotosphere does not get updated in an event listener
       setCurrentPhotosphere((currentState) => {
-        const passMarker = currentState.hotspots[marker.config.id];
-        setHotspotArray([passMarker]);
+        let passMarker = currentState.hotspots[marker.config.id];
+        let passMarkerList = [passMarker];
+
+        const lastEditedHotspotFlag = Number(sessionStorage.getItem('lastEditedHotspotFlag'));
+        const lastEditedHotspot = JSON.parse(sessionStorage.getItem('lastEditedHotspot'));
+
+        if (lastEditedHotspotFlag == 1 && lastEditedHotspot != null && lastEditedHotspot.length > 1 && lastEditedHotspot[0] == marker.config.id) {
+          for (let i = 1; i < lastEditedHotspot.length; ++i) {
+            passMarkerList.push( passMarker.data.hotspots[lastEditedHotspot[i]] );
+            passMarker = passMarker.data.hotspots[lastEditedHotspot[i]];
+          }
+          sessionStorage.setItem('lastEditedHotspotFlag', "0");
+        }
+
+        setHotspotArray(passMarkerList);
         handleVisit(currentState.id, marker.config.id);
         return currentState;
       });


### PR DESCRIPTION
At the moment, I've implemented the "saving last nested hotspot" functionality. When the user clicks the save button in a nested hotspot and clicks the hotspot they were editing before the page updated, it will automatically go to the nested hotspot they last saved on. Will default back to the head hotspot when closing the editing menu without clicking the save button.

To come later:
- Have the hotspot menu automatically reappear after the page updates, rather than requiring the user to navigate back to the hotspot
- Implement "Save" and "Save and Exit" buttons so that the editing user can choose to stay in that hotspot or go to a different one after saving