### PR TITLE
Ws 61 points interface and progress bar

### DIFF
--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -1,0 +1,60 @@
+import localforage from "localforage";
+import { useState } from "react";
+
+// Using a separite instance of localforage so we dont interfere with loading of VFEs
+const pointsStore = localforage.createInstance({
+  name: "pointsStore",
+});
+
+const points = await pointsStore.getItem<number>("Points");
+
+export const getPoints = () => {
+  return points;
+};
+
+//Can also be used to reset points
+export function InitializePoints() {
+  pointsStore
+    .setItem("Points", 0)
+    .then(() => {
+      window.dispatchEvent(new Event("storage"));
+      console.log("Points initialized successfully!");
+    })
+    .catch((error) => {
+      console.error("Error storing data:", error);
+    });
+}
+
+export function usePoints() {
+  const [points, setPoints] = useState(getPoints());
+  // will need a set maxPoints function eventually that saves the max points to VFE
+  // save data when changed in the editor
+
+  //Increment Points by Amount, must be whole number
+  async function AddPoints(amount: number) {
+    let pointsStorage = await pointsStore.getItem<number>("Points");
+
+    if (pointsStorage != null) {
+      pointsStorage = pointsStorage + amount;
+      setPoints(pointsStorage);
+    } else {
+      console.log("No Points!");
+      return;
+    }
+
+    pointsStore
+      .setItem("Points", pointsStorage)
+      .then(() => {
+        console.log(
+          "Points updated successfully! New points are: " + pointsStorage,
+        );
+        window.dispatchEvent(new Event("storage"));
+        return;
+      })
+      .catch((error) => {
+        console.error("Error storing data:", error);
+      });
+  }
+
+  return [points, AddPoints] as const;
+}

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -5,6 +5,16 @@ import { useNavigate } from "react-router-dom";
 import AttachFileIcon from "@mui/icons-material/AttachFile";
 import { Box, Button, Stack } from "@mui/material";
 
+import { VisitedState } from "../Hooks/HandleVisit.tsx";
+import PhotosphereTutorialEditor from "../PhotosphereFeatures/PhotosphereTutorialEditor";
+import { alertMUI, confirmMUI } from "../UI/StyledDialogWrapper.tsx";
+import AddAudio from "../buttons/AddAudio.tsx";
+import AddHotspot from "../buttons/AddHotspot.tsx";
+import AddNavmap from "../buttons/AddNavmap.tsx";
+import AddPhotosphere from "../buttons/AddPhotosphere.tsx";
+import ChangePhotosphere from "../buttons/ChangePhotosphere.tsx";
+import EditNavMap from "../buttons/EditNavMap.tsx";
+import RemovePhotosphere from "../buttons/RemovePhotosphere.tsx";
 import {
   Hotspot3D,
   NavMap,
@@ -15,23 +25,14 @@ import {
   photosphereLinkTooltip,
 } from "./PageUtility/DataStructures.ts";
 import { deleteStoredVFE, save } from "./PageUtility/FileOperations.ts";
-import { VisitedState } from "../Hooks/HandleVisit.tsx";
-import PhotosphereViewer from "./PhotosphereViewer.tsx";
-import { alertMUI, confirmMUI } from "../UI/StyledDialogWrapper.tsx";
+import { InitializePoints } from "./PageUtility/PointsInterface.tsx";
 import {
   HotspotUpdate,
   convertRuntimeToStored,
   convertVFE,
   updatePhotosphereHotspot,
 } from "./PageUtility/VFEConversion.ts";
-import AddAudio from "../buttons/AddAudio.tsx";
-import AddHotspot from "../buttons/AddHotspot.tsx";
-import AddNavmap from "../buttons/AddNavmap.tsx";
-import AddPhotosphere from "../buttons/AddPhotosphere.tsx";
-import ChangePhotosphere from "../buttons/ChangePhotosphere.tsx";
-import EditNavMap from "../buttons/EditNavMap.tsx";
-import RemovePhotosphere from "../buttons/RemovePhotosphere.tsx";
-import PhotosphereTutorialEditor from "../PhotosphereFeatures/PhotosphereTutorialEditor";
+import PhotosphereViewer from "./PhotosphereViewer.tsx";
 
 /** Convert from radians to degrees */
 function radToDeg(num: number): number {
@@ -132,8 +133,8 @@ function PhotosphereEditor({
       },
     };
 
-    sessionStorage.setItem('lastEditedHotspot', JSON.stringify(hotspotPath));
-    sessionStorage.setItem('lastEditedHotspotFlag', "1");
+    sessionStorage.setItem("lastEditedHotspot", JSON.stringify(hotspotPath));
+    sessionStorage.setItem("lastEditedHotspotFlag", "1");
 
     onUpdateVFE(updatedVFE);
     setUpdateTrigger((prev) => prev + 1);
@@ -439,8 +440,8 @@ function PhotosphereEditor({
     );
   }
 
-const [runTutorial, setRunTutorial] = useState(false);
-const [stepIndex, setStepIndex] = useState(0);
+  const [runTutorial, setRunTutorial] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
 
   return (
     <Box sx={{ height: "100vh" }}>
@@ -504,6 +505,15 @@ const [stepIndex, setStepIndex] = useState(0);
               variant="contained"
             >
               Export
+            </Button>
+            <Button
+              sx={{ margin: "10px 0" }}
+              onClick={() => {
+                InitializePoints();
+              }}
+              variant="contained"
+            >
+              Gamify!
             </Button>
           </>
         )}

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -13,6 +13,7 @@ import {
 } from "@mui/material";
 
 import { Photosphere, VFE } from "../Pages/PageUtility/DataStructures";
+import { usePoints } from "../Pages/PageUtility/PointsInterface.tsx";
 import { HotspotUpdate } from "../Pages/PageUtility/VFEConversion";
 import PhotosphereHotspotSideBar from "../PhotosphereFeatures/PhotosphereHotspotSidebar.tsx";
 import PhotospherePlaceholder from "../PhotosphereFeatures/PhotospherePlaceholder";
@@ -118,6 +119,9 @@ function PhotosphereViewer({
 
   const [isSplitView, setIsSplitView] = useState(false);
   const [lockViews, setLockViews] = useState(false);
+
+  const [points, AddPoints] = usePoints();
+  const maxPoints = 100;
 
   const viewerProps: ViewerProps = {
     vfe,
@@ -274,6 +278,30 @@ function PhotosphereViewer({
           }}
         />
       </Box>
+      <Stack
+        direction="row"
+        sx={{
+          position: "absolute",
+          bottom: "44px",
+          left: 0,
+          right: 0,
+          maxWidth: "100%",
+          width: "fit-content",
+          minWidth: "150px",
+          height: "25px",
+          padding: "4px",
+          margin: "auto",
+          backgroundColor: "white",
+          borderRadius: "4px",
+          boxShadow: "0 0 4px grey",
+          zIndex: 100,
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+        gap={1}
+      >
+        <progress value={points ?? 0} max={maxPoints} />{" "}
+      </Stack>
     </>
   );
 }

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -222,6 +222,18 @@ function PhotosphereViewer({
           }}
           sx={{ margin: 0 }}
         />
+        <Box sx={{ padding: "0 5px" }}>
+          <Button
+            sx={{ padding: "0", width: "4px", height: "40px" }}
+            variant="contained"
+            color="primary"
+            onClick={() => {
+              void AddPoints(10);
+            }}
+          >
+            Add Points!
+          </Button>
+        </Box>
       </Stack>
       <Stack
         direction="row"


### PR DESCRIPTION
Created a points interface that handles setting up and updating a points total in local storage using the localForage library, as well as a progress bar that displays the overall current point totals. Two buttons have been added for testing and demonstration, one in the editor (Gamify!) and one in the viewer (Add Points) that also shows up in the editor. The gamify button sets up the local storage if it is not prepared already, and sets or resets the current point total to 0. The Add Points button adds 10 points to the score. Current max points is 100, will eventually make that into a user-defined value.

Known issues: Reset is not dynamic yet.

If you find any other issues, please let me know! Major MVP props to Braulee for his help!