### PR TITLE
Ws 64 gamification toggle

### DIFF
--- a/src/Pages/App.tsx
+++ b/src/Pages/App.tsx
@@ -2,19 +2,24 @@ import localforage from "localforage";
 import { Route, Routes, useNavigate } from "react-router-dom";
 
 import CreateVFEForm from "../Pages/CreateVFE.tsx";
+import LandingPage from "../Pages/LandingPage.tsx";
+import Prototype from "../Prototype/Prototype.tsx";
 import { VFE } from "./PageUtility/DataStructures.ts";
 import { load } from "./PageUtility/FileOperations.ts";
-import LandingPage from "../Pages/LandingPage.tsx";
+import { useGamificationState } from "./PageUtility/PointsInterface.tsx";
+import {
+  convertRuntimeToStored,
+  convertVFE,
+} from "./PageUtility/VFEConversion.ts";
+import VFELoader from "./PageUtility/VFELoader.tsx";
 import PhotosphereEditor from "./PhotosphereEditor.tsx";
 import PhotosphereViewer from "./PhotosphereViewer.tsx";
-import Prototype from "../Prototype/Prototype.tsx";
-import { convertRuntimeToStored, convertVFE } from "./PageUtility/VFEConversion.ts";
-import VFELoader from "./PageUtility/VFELoader.tsx";
 
 // Main component acts as a main entry point for the application
 // Should decide what we are doing, going to LandingPage/Rendering VFE
 function AppRoot() {
   const navigate = useNavigate();
+  const [isGamified] = useGamificationState();
 
   //Create a function to set useState true
   function handleLoadTestVFE() {
@@ -79,7 +84,11 @@ function AppRoot() {
       <Route
         path="/viewer/:vfeID"
         element={
-          <VFELoader render={(props) => <PhotosphereViewer {...props} />} />
+          <VFELoader
+            render={(props) => (
+              <PhotosphereViewer isGamified={isGamified ?? false} {...props} />
+            )}
+          />
         }
       >
         <Route path=":photosphereID" element={null} />

--- a/src/Pages/App.tsx
+++ b/src/Pages/App.tsx
@@ -36,7 +36,6 @@ function AppRoot() {
       convertRuntimeToStored(networkVFE.name),
     );
     await localforage.setItem(localVFE.name, localVFE);
-    await SetGamifyState(localVFE.gamificationToggle ?? false);
     navigate(`/editor/${localVFE.name}/${localVFE.defaultPhotosphereID}`);
   }
 
@@ -44,6 +43,9 @@ function AppRoot() {
     const localVFE = await load(file);
     if (localVFE) {
       await localforage.setItem(localVFE.name, localVFE);
+      console.log("The state from save is: " + localVFE.gamificationToggle);
+      await SetGamifyState(localVFE.gamificationToggle ?? false);
+      console.log("The state in local memory is: " + isGamified);
       const target = openInViewer ? "viewer" : "editor";
       navigate(`/${target}/${localVFE.name}/${localVFE.defaultPhotosphereID}`);
     }

--- a/src/Pages/App.tsx
+++ b/src/Pages/App.tsx
@@ -19,7 +19,7 @@ import PhotosphereViewer from "./PhotosphereViewer.tsx";
 // Should decide what we are doing, going to LandingPage/Rendering VFE
 function AppRoot() {
   const navigate = useNavigate();
-  const [isGamified] = useGamificationState();
+  const [isGamified, , SetGamifyState] = useGamificationState();
 
   //Create a function to set useState true
   function handleLoadTestVFE() {
@@ -36,6 +36,7 @@ function AppRoot() {
       convertRuntimeToStored(networkVFE.name),
     );
     await localforage.setItem(localVFE.name, localVFE);
+    await SetGamifyState(localVFE.gamificationToggle ?? false);
     navigate(`/editor/${localVFE.name}/${localVFE.defaultPhotosphereID}`);
   }
 

--- a/src/Pages/PageUtility/DataStructures.ts
+++ b/src/Pages/PageUtility/DataStructures.ts
@@ -49,6 +49,7 @@ export interface VFE {
   map?: NavMap;
   defaultPhotosphereID: string;
   photospheres: Record<string, Photosphere>;
+  gamificationToggle?: boolean;
 }
 
 // Navigation map: a birdseye view of the various hotspots within a single 360-environment

--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -88,7 +88,7 @@ export function useGamificationState() {
     } else {
       console.log("No State, intialize!");
       InitializeState();
-      return;
+      setGamifiedState(true);
     }
 
     pointsStore
@@ -101,10 +101,19 @@ export function useGamificationState() {
       .catch((error) => {
         console.error("Error storing data:", error);
       });
+    return;
   }
 
   async function SetGamifyState(state: boolean) {
-    setGamifiedState(state);
+    let stateStorage = await pointsStore.getItem<boolean>("GamifiedState");
+
+    if (stateStorage != null) {
+      setGamifiedState(state);
+    } else {
+      console.log("No State, intialize!");
+      InitializeState();
+      setGamifiedState(state);
+    }
     pointsStore
       .setItem("GamifiedState", state)
       .then(() => {
@@ -115,6 +124,7 @@ export function useGamificationState() {
       .catch((error) => {
         console.error("Error storing data:", error);
       });
+    return;
   }
 
   return [gamifiedState, SwapGamifyState, SetGamifyState] as const;

--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -7,9 +7,14 @@ const pointsStore = localforage.createInstance({
 });
 
 const points = await pointsStore.getItem<number>("Points");
+const gamifiedState = await pointsStore.getItem<boolean>("GamifiedState");
 
 export const getPoints = () => {
   return points;
+};
+
+export const getGamifiedState = () => {
+  return gamifiedState;
 };
 
 //Can also be used to reset points
@@ -22,6 +27,18 @@ export function InitializePoints() {
     })
     .catch((error) => {
       console.error("Error storing data:", error);
+    });
+}
+
+export function InitializeState() {
+  pointsStore
+    .setItem("GamifiedState", true)
+    .then(() => {
+      window.dispatchEvent(new Event("storage"));
+      console.log("State initialized successfully!");
+    })
+    .catch((error) => {
+      console.error("Error storing state data:", error);
     });
 }
 
@@ -57,4 +74,35 @@ export function usePoints() {
   }
 
   return [points, AddPoints] as const;
+}
+
+export function useGamificationState() {
+  const [gamifiedState, setGamifiedState] = useState(getGamifiedState());
+
+  async function SwapGamifyState() {
+    let stateStorage = await pointsStore.getItem<boolean>("GamifiedState");
+    InitializePoints();
+
+    if (stateStorage != null) {
+      stateStorage = !stateStorage;
+      setGamifiedState(stateStorage);
+    } else {
+      console.log("No State, intialize!");
+      InitializeState();
+      return;
+    }
+
+    pointsStore
+      .setItem("GamifiedState", stateStorage)
+      .then(() => {
+        console.log("The state storage is: " + stateStorage);
+        window.dispatchEvent(new Event("storage"));
+        return;
+      })
+      .catch((error) => {
+        console.error("Error storing data:", error);
+      });
+  }
+
+  return [gamifiedState, SwapGamifyState] as const;
 }

--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -103,5 +103,18 @@ export function useGamificationState() {
       });
   }
 
-  return [gamifiedState, SwapGamifyState] as const;
+  async function SetGamifyState(state: boolean) {
+    pointsStore
+      .setItem("GamifiedState", state)
+      .then(() => {
+        console.log("The state storage was set to: " + state);
+        window.dispatchEvent(new Event("storage"));
+        return;
+      })
+      .catch((error) => {
+        console.error("Error storing data:", error);
+      });
+  }
+
+  return [gamifiedState, SwapGamifyState, SetGamifyState] as const;
 }

--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -104,6 +104,7 @@ export function useGamificationState() {
   }
 
   async function SetGamifyState(state: boolean) {
+    setGamifiedState(state);
     pointsStore
       .setItem("GamifiedState", state)
       .then(() => {

--- a/src/Pages/PageUtility/PointsInterface.tsx
+++ b/src/Pages/PageUtility/PointsInterface.tsx
@@ -17,7 +17,6 @@ export const getGamifiedState = () => {
   return gamifiedState;
 };
 
-//Can also be used to reset points
 export function InitializePoints() {
   pointsStore
     .setItem("Points", 0)

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -446,7 +446,7 @@ function PhotosphereEditor({
   const [runTutorial, setRunTutorial] = useState(false);
   const [stepIndex, setStepIndex] = useState(0);
 
-  const [, SwapGamifyState] = useGamificationState();
+  const [gamifiedState, SwapGamifyState] = useGamificationState();
 
   return (
     <Box sx={{ height: "100vh" }}>
@@ -657,6 +657,7 @@ function PhotosphereEditor({
           onUpdateHotspot={(hotspotPath, update) => {
             void handleUpdateHotspot(hotspotPath, update);
           }}
+          isGamified={gamifiedState ?? false}
         />
         <ActiveComponent />
       </Box>

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -25,10 +25,7 @@ import {
   photosphereLinkTooltip,
 } from "./PageUtility/DataStructures.ts";
 import { deleteStoredVFE, save } from "./PageUtility/FileOperations.ts";
-import {
-  useGamificationState,
-  usePoints,
-} from "./PageUtility/PointsInterface.tsx";
+import { useGamificationState } from "./PageUtility/PointsInterface.tsx";
 import {
   HotspotUpdate,
   convertRuntimeToStored,

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -510,9 +510,9 @@ function PhotosphereEditor({
             </Button>
             <Button
               sx={{ margin: "10px 0" }}
-              onClick={() => {
-                SwapGamifyState();
-                //its always setting it to the opposite of what it should be for some reason
+              onClick={async () => {
+                await SwapGamifyState();
+                //correcting for it always setting saved state to the opposite of what it should be for some reason.  Timing issue?
                 vfe.gamificationToggle = !gamifiedState;
                 console.log(
                   "The gamified state is: " +

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -72,6 +72,8 @@ function PhotosphereEditor({
   const [showChangeFeatures, setShowChangeFeatures] = useState(false);
   const [showRemoveFeatures, setShowRemoveFeatures] = useState(false);
 
+  const [gamifiedState, SwapGamifyState] = useGamificationState();
+
   const visitedState = JSON.parse(
     localStorage.getItem("visitedState") ?? "{}",
   ) as VisitedState;
@@ -442,8 +444,6 @@ function PhotosphereEditor({
 
   const [runTutorial, setRunTutorial] = useState(false);
   const [stepIndex, setStepIndex] = useState(0);
-
-  const [gamifiedState, SwapGamifyState] = useGamificationState();
 
   return (
     <Box sx={{ height: "100vh" }}>

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -25,7 +25,10 @@ import {
   photosphereLinkTooltip,
 } from "./PageUtility/DataStructures.ts";
 import { deleteStoredVFE, save } from "./PageUtility/FileOperations.ts";
-import { InitializePoints } from "./PageUtility/PointsInterface.tsx";
+import {
+  useGamificationState,
+  usePoints,
+} from "./PageUtility/PointsInterface.tsx";
 import {
   HotspotUpdate,
   convertRuntimeToStored,
@@ -443,6 +446,8 @@ function PhotosphereEditor({
   const [runTutorial, setRunTutorial] = useState(false);
   const [stepIndex, setStepIndex] = useState(0);
 
+  const [, SwapGamifyState] = useGamificationState();
+
   return (
     <Box sx={{ height: "100vh" }}>
       <PhotosphereTutorialEditor
@@ -509,7 +514,7 @@ function PhotosphereEditor({
             <Button
               sx={{ margin: "10px 0" }}
               onClick={() => {
-                InitializePoints();
+                SwapGamifyState();
               }}
               variant="contained"
             >

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -512,6 +512,14 @@ function PhotosphereEditor({
               sx={{ margin: "10px 0" }}
               onClick={() => {
                 SwapGamifyState();
+                //its always setting it to the opposite of what it should be for some reason
+                vfe.gamificationToggle = !gamifiedState;
+                console.log(
+                  "The gamified state is: " +
+                    !gamifiedState +
+                    " and the vfe gamification state is: " +
+                    vfe.gamificationToggle,
+                );
               }}
               variant="contained"
             >

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -82,6 +82,7 @@ export interface PhotosphereViewerProps {
     update: HotspotUpdate | null,
   ) => void;
   photosphereOptions?: string[];
+  isGamified: boolean;
 }
 
 export interface ViewerStates {
@@ -110,6 +111,7 @@ function PhotosphereViewer({
   onViewerClick,
   onUpdateHotspot,
   photosphereOptions,
+  isGamified,
 }: PhotosphereViewerProps) {
   const primaryPsRef = React.useRef<ViewerAPI | null>(null);
   const splitRef = React.useRef<ViewerAPI | null>(null);
@@ -124,8 +126,6 @@ function PhotosphereViewer({
   const [lockViews, setLockViews] = useState(false);
 
   const [points, AddPoints] = usePoints();
-  const [Gamified] = useGamificationState();
-  console.log("viewer gamified is: " + Gamified);
 
   const maxPoints = 100;
 
@@ -228,7 +228,7 @@ function PhotosphereViewer({
           }}
           sx={{ margin: 0 }}
         />
-        {Gamified && (
+        {isGamified && (
           <Box sx={{ padding: "0 5px" }}>
             <Button
               sx={{ padding: "0", width: "4px", height: "40px" }}
@@ -298,30 +298,32 @@ function PhotosphereViewer({
           }}
         />
       </Box>
-      <Stack
-        direction="row"
-        sx={{
-          position: "absolute",
-          bottom: "44px",
-          left: 0,
-          right: 0,
-          maxWidth: "100%",
-          width: "fit-content",
-          minWidth: "150px",
-          height: "25px",
-          padding: "4px",
-          margin: "auto",
-          backgroundColor: "white",
-          borderRadius: "4px",
-          boxShadow: "0 0 4px grey",
-          zIndex: 100,
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-        gap={1}
-      >
-        <progress value={points ?? 0} max={maxPoints} />{" "}
-      </Stack>
+      {isGamified && (
+        <Stack
+          direction="row"
+          sx={{
+            position: "absolute",
+            bottom: "44px",
+            left: 0,
+            right: 0,
+            maxWidth: "100%",
+            width: "fit-content",
+            minWidth: "150px",
+            height: "25px",
+            padding: "4px",
+            margin: "auto",
+            backgroundColor: "white",
+            borderRadius: "4px",
+            boxShadow: "0 0 4px grey",
+            zIndex: 100,
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+          gap={1}
+        >
+          <progress value={points ?? 0} max={maxPoints} />{" "}
+        </Stack>
+      )}
     </>
   );
 }

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -13,10 +13,7 @@ import {
 } from "@mui/material";
 
 import { Photosphere, VFE } from "../Pages/PageUtility/DataStructures";
-import {
-  useGamificationState,
-  usePoints,
-} from "../Pages/PageUtility/PointsInterface.tsx";
+import { usePoints } from "../Pages/PageUtility/PointsInterface.tsx";
 import { HotspotUpdate } from "../Pages/PageUtility/VFEConversion";
 import PhotosphereHotspotSideBar from "../PhotosphereFeatures/PhotosphereHotspotSidebar.tsx";
 import PhotospherePlaceholder from "../PhotosphereFeatures/PhotospherePlaceholder";

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -13,7 +13,10 @@ import {
 } from "@mui/material";
 
 import { Photosphere, VFE } from "../Pages/PageUtility/DataStructures";
-import { usePoints } from "../Pages/PageUtility/PointsInterface.tsx";
+import {
+  useGamificationState,
+  usePoints,
+} from "../Pages/PageUtility/PointsInterface.tsx";
 import { HotspotUpdate } from "../Pages/PageUtility/VFEConversion";
 import PhotosphereHotspotSideBar from "../PhotosphereFeatures/PhotosphereHotspotSidebar.tsx";
 import PhotospherePlaceholder from "../PhotosphereFeatures/PhotospherePlaceholder";
@@ -121,6 +124,9 @@ function PhotosphereViewer({
   const [lockViews, setLockViews] = useState(false);
 
   const [points, AddPoints] = usePoints();
+  const [Gamified] = useGamificationState();
+  console.log("viewer gamified is: " + Gamified);
+
   const maxPoints = 100;
 
   const viewerProps: ViewerProps = {
@@ -222,18 +228,20 @@ function PhotosphereViewer({
           }}
           sx={{ margin: 0 }}
         />
-        <Box sx={{ padding: "0 5px" }}>
-          <Button
-            sx={{ padding: "0", width: "4px", height: "40px" }}
-            variant="contained"
-            color="primary"
-            onClick={() => {
-              void AddPoints(10);
-            }}
-          >
-            Add Points!
-          </Button>
-        </Box>
+        {Gamified && (
+          <Box sx={{ padding: "0 5px" }}>
+            <Button
+              sx={{ padding: "0", width: "4px", height: "40px" }}
+              variant="contained"
+              color="primary"
+              onClick={() => {
+                void AddPoints(10);
+              }}
+            >
+              Add Points!
+            </Button>
+          </Box>
+        )}
       </Stack>
       <Stack
         direction="row"


### PR DESCRIPTION
Added: Gamification button in editor now swaps and saves the gamification state, either true or false.  If true, the gamification elements are shown, if false, they are hidden.  Weather or not the VFE is gamified is now exported to the save file and loaded when the file is loaded.  

Known Bugs:  
- Loading the VFE into the viewer works as expected.  Loading the VFE into the editor will use whatever gamification state is currently in local memory to render the page and only change to the correct state if the page is reloaded.  Uncertain how this is possible at this time.  Timing issue?  Not setting the state early enough? 
- Minor bug setting the gamification state for saving....it was always saving the opposite state it should have.  Currently corrected for in code, but I am seeking a better solution than simply setting the saved state to what it should be.  

 